### PR TITLE
Use JSDom testing environment for Unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,18 @@ const config = {
         statements: 80,
       },
     },
+    projects: [
+      {
+        'displayName': 'browser',
+        'testEnvironment': 'jest-environment-jsdom',
+        'testMatch': ['**/tests/unit/**'],
+      },
+      {
+        "displayName": "node",
+        "testEnvironment": "node",
+        "testMatch": ["**/tests/integration/**"]
+      }
+    ],
   };
   
   module.exports = config;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "eslint": "^9.14.0",
     "globals": "^15.12.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.2.0",
     "puppeteer": "^23.8.0"
   },
   "scripts": {


### PR DESCRIPTION
### Issue Ticket Number and Link
N/A

### Reason of Changes
Using JSDom testing environment allows us to supply the DOM directly to our tests during unit tests. 
Puppeteer will continue to use websocket but Unit tests can utilize modifying the DOM directly

### How the Changes were made
Added JSDom env to unit tests but not integration tests

### Testing
Passes coverage/current tests

### Checklist

- [x] All tests pass locally.
- [x] Code is self-documented or comments have been added where necessary.
- [x] New code follows the project's coding style and guidelines.
- [ ] Relevant documentation has been updated (e.g., README, Wiki).

---
